### PR TITLE
Use try_join! when running controllers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,9 +76,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "2da1976d75adbe5fbc88130ecd119529cf1cc6a93ae1546d8696ee66f0d21af1"
 
 [[package]]
 name = "bumpalo"
@@ -787,9 +787,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
 name = "linked-hash-map"
@@ -851,9 +851,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
+checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
 dependencies = [
  "lazy_static",
  "libc",
@@ -1438,7 +1438,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 [[package]]
 name = "stackable-operator"
 version = "0.1.0-nightly"
-source = "git+https://github.com/stackabletech/operator-rs.git?branch=main#4394131b2c1326129b97a1b8b97d24dc85c30f70"
+source = "git+https://github.com/stackabletech/operator-rs.git?branch=main#732baf5351058e6e507e34756e987407aba87cbe"
 dependencies = [
  "async-trait",
  "backoff",

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -28,11 +28,8 @@ async fn main() -> Result<(), error::Error> {
         return Err(error);
     };
 
-    // TODO: the call to create_controller() cannot be made inside the join! below because
-    //       that would ignore possible Err returned. A better approach would be to use
-    //       try_join! and refactor the create_command_controller() to return a Result.
-    stackable_spark_operator::create_controller(client.clone()).await?;
-    tokio::join!(
+    tokio::try_join!(
+        stackable_spark_operator::create_controller(client.clone()),
         stackable_operator::command_controller::create_command_controller::<Restart, SparkCluster>(
             client.clone()
         ),
@@ -42,7 +39,7 @@ async fn main() -> Result<(), error::Error> {
         stackable_operator::command_controller::create_command_controller::<Stop, SparkCluster>(
             client.clone()
         )
-    );
+    )?;
 
     Ok(())
 }


### PR DESCRIPTION
Now that `create_command_controller`returns a `Result` we can use `try_join!` when running multiple controllers.