### PR TITLE
Only print diagnostic output _after_ CLI has been handled & cargo update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,9 +167,9 @@ dependencies = [
 
 [[package]]
 name = "const_format"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49aad96768495418a04c9349327f32f2cd7e9bf8ac6b142534466048721c8ff5"
+checksum = "59c7d3aa11be45d56befebb10f4a8785fcb62aabddf5f33638efef922e505ec9"
 dependencies = [
  "const_format_proc_macros",
 ]
@@ -584,9 +584,9 @@ checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
 name = "hyper"
-version = "0.14.11"
+version = "0.14.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b61cf2d1aebcf6e6352c97b81dc2244ca29194be1b276f5d8ad5c6330fffb11"
+checksum = "13f67199e765030fa08fe0bd581af683f0d5bc04ea09c2b1102012c5fb90e7fd"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1395,9 +1395,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.128"
+version = "1.0.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1056a0db1978e9dbf0f6e4fca677f6f9143dc1c19de346f22cac23e422196834"
+checksum = "d1f72836d2aa753853178eda473a3b9d8e4eefdaf20523b919677e6de489f8f1"
 dependencies = [
  "serde_derive",
 ]
@@ -1414,9 +1414,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.128"
+version = "1.0.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13af2fbb8b60a8950d6c72a56d2095c28870367cc8e10c55e9745bac4995a2c4"
+checksum = "e57ae87ad533d9a56427558b516d0adac283614e347abf85b0dc0cbbf0a249f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1530,7 +1530,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 [[package]]
 name = "stackable-operator"
 version = "0.1.0-nightly"
-source = "git+https://github.com/stackabletech/operator-rs.git?branch=main#ed04ff725de4167ca70857431eded3209d9caf20"
+source = "git+https://github.com/stackabletech/operator-rs.git?branch=main#2554705f7a25d7b9366c37d57dbbaa6c45a0c95c"
 dependencies = [
  "async-trait",
  "backoff",
@@ -1551,6 +1551,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "strum",
+ "strum_macros",
  "thiserror",
  "tokio",
  "tracing",
@@ -1760,9 +1762,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cf844b23c6131f624accf65ce0e4e9956a8bb329400ea5bcc26ae3a5c20b0b"
+checksum = "92036be488bb6594459f2e03b60e42df6f937fe6ca5c5ffdcb539c6b84dc40f5"
 dependencies = [
  "autocfg",
  "libc",

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -14,15 +14,6 @@ mod built_info {
 async fn main() -> anyhow::Result<()> {
     stackable_operator::logging::initialize_logging("SPARK_OPERATOR_LOG");
 
-    stackable_operator::utils::print_startup_string(
-        built_info::PKG_DESCRIPTION,
-        built_info::PKG_VERSION,
-        built_info::GIT_VERSION,
-        built_info::TARGET,
-        built_info::BUILT_TIME_UTC,
-        built_info::RUSTC_VERSION,
-    );
-
     // Handle CLI arguments
     let matches = App::new(built_info::PKG_DESCRIPTION)
         .author("Stackable GmbH - info@stackable.de")
@@ -54,6 +45,15 @@ async fn main() -> anyhow::Result<()> {
         "/etc/stackable/spark-operator/config-spec/properties.yaml",
     ];
     let product_config_path = cli::handle_productconfig_arg(&matches, paths)?;
+
+    stackable_operator::utils::print_startup_string(
+        built_info::PKG_DESCRIPTION,
+        built_info::PKG_VERSION,
+        built_info::GIT_VERSION,
+        built_info::TARGET,
+        built_info::BUILT_TIME_UTC,
+        built_info::RUSTC_VERSION,
+    );
 
     let client = client::create_client(Some("spark.stackable.tech".to_string())).await?;
 


### PR DESCRIPTION
This only moves the diagnostic print stuff to after the CLI handling.
It also includes a cargo update

/fixes #123 