### PR TITLE
[Merged by Bors] - Support specifying a namespace to watch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,16 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Reconciliation errors are now reported as Kubernetes events ([#289]).
+- Use cli argument `watch-namespace` / env var `WATCH_NAMESPACE` to specify
+  a single namespace to watch ([#297]).
 
 ### Changed
 
-- `operator-rs` `0.10.0` -> `0.12.0` ([#289], [#291]).
+- `operator-rs` `0.10.0` -> `0.13.0` ([#289], [#291], [#297]).
 
 [#289]: https://github.com/stackabletech/spark-operator/pull/289
 [#291]: https://github.com/stackabletech/spark-operator/pull/291
+[#297]: https://github.com/stackabletech/spark-operator/pull/297
 
 ## [0.5.0] - 2022-02-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,9 +33,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.53"
+version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
+checksum = "159bb86af3a200e19a068f4224eae4c8bb2d0fa054c7e5d1cacd5cef95e684cd"
 
 [[package]]
 name = "atty"
@@ -137,9 +137,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f1fea81f183005ced9e59cdb01737ef2423956dac5a6d731b06b2ecfaa3467"
+checksum = "5177fac1ab67102d8989464efd043c6ff44191b1557ec1ddd489b4f7e1447e77"
 dependencies = [
  "atty",
  "bitflags",
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd1122e63869df2cb309f449da1ad54a7c6dfeb7c7e6ccd8e0825d9eb93bb72"
+checksum = "01d42c94ce7c2252681b5fed4d3627cc807b13dfc033246bd05d5b252399000e"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -488,9 +488,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
+checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
 dependencies = [
  "cfg-if",
  "libc",
@@ -839,9 +839,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.118"
+version = "0.2.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e509672465a0504304aa87f9f176f2b2b716ed8fb105ebe5c02dc6dce96a94"
+checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
 name = "libgit2-sys"
@@ -1360,9 +1360,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0486718e92ec9a68fbed73bb5ef687d71103b142595b406835649bebd33f72c7"
+checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
 dependencies = [
  "serde",
 ]
@@ -1496,8 +1496,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.12.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.12.0#ac525b91421f7b0d4c74462627bf13e59be5661b"
+version = "0.13.0"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.13.0#401f4053d8c32d0fcd507d94799956181f66105d"
 dependencies = [
  "backoff",
  "chrono",
@@ -1517,7 +1517,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "strum",
+ "strum 0.23.0",
  "thiserror",
  "tokio",
  "tracing",
@@ -1534,8 +1534,7 @@ dependencies = [
  "serde_yaml",
  "snafu",
  "stackable-operator",
- "strum",
- "strum_macros",
+ "strum 0.24.0",
 ]
 
 [[package]]
@@ -1552,8 +1551,7 @@ dependencies = [
  "snafu",
  "stackable-operator",
  "stackable-spark-crd",
- "strum",
- "strum_macros",
+ "strum 0.24.0",
  "tokio",
  "tracing",
 ]
@@ -1570,7 +1568,16 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.23.1",
+]
+
+[[package]]
+name = "strum"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e96acfc1b70604b8b2f1ffa4c57e59176c7dbb05d556c71ecd2f5498a1dee7f8"
+dependencies = [
+ "strum_macros 0.24.0",
 ]
 
 [[package]]
@@ -1580,6 +1587,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
 dependencies = [
  "heck 0.3.3",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef"
+dependencies = [
+ "heck 0.4.0",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -1785,9 +1805,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ed53e1fd082268841975cb39587fa9fca9a7a30da84f97818ef667c97f2872"
+checksum = "2bb284cac1883d54083a0edbdc9cabf931dfed87455f8c7266c01ece6394a43a"
 dependencies = [
  "base64",
  "bitflags",
@@ -1817,9 +1837,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d8d93354fe2a8e50d5953f5ae2e47a3fc2ef03292e7ea46e3cc38f549525fb9"
+checksum = "f6c650a8ef0cd2dd93736f033d21cbd1224c5a967aa0c258d00fcf7dafef9b9f"
 dependencies = [
  "cfg-if",
  "log",
@@ -1862,9 +1882,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74786ce43333fcf51efe947aed9718fbe46d5c7328ec3f1029e818083966d9aa"
+checksum = "9e0ab7bdc962035a87fba73f3acca9b8a8d0034c2e6f60b84aeaaddddc155dce"
 dependencies = [
  "ansi_term",
  "lazy_static",

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,2 +1,3 @@
 * xref:installation.adoc[]
+* xref:configuration.adoc[]
 * xref:usage.adoc[]

--- a/docs/modules/ROOT/pages/commandline_args.adoc
+++ b/docs/modules/ROOT/pages/commandline_args.adoc
@@ -7,5 +7,22 @@
 
 *Multiple values:* false
 
-This file contains property definitions for the Apache Spark configuration.
+[source]
+----
+cargo run -- run --product-config /foo/bar/properties.yaml
+----
 
+=== watch-namespace
+
+*Default value*: All namespaces
+
+*Required*: false
+
+*Multiple values:* false
+
+The operator will **only** watch for resources in the provided namespace `test`:
+
+[source]
+----
+cargo run -- run --watch-namespace test
+----

--- a/docs/modules/ROOT/pages/commandline_args.adoc
+++ b/docs/modules/ROOT/pages/commandline_args.adoc
@@ -9,7 +9,7 @@
 
 [source]
 ----
-cargo run -- run --product-config /foo/bar/properties.yaml
+stackable-spark-operator run --product-config /foo/bar/properties.yaml
 ----
 
 === watch-namespace
@@ -24,5 +24,5 @@ The operator will **only** watch for resources in the provided namespace `test`:
 
 [source]
 ----
-cargo run -- run --watch-namespace test
+stackable-spark-operator run --watch-namespace test
 ----

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -1,0 +1,13 @@
+= Configuration
+
+== Command Line Parameters
+
+This operator accepts the following command line parameters:
+
+include::commandline_args.adoc[]
+
+== Environment variables
+
+This operator accepts the following environment variables:
+
+include::env_var_args.adoc[]

--- a/docs/modules/ROOT/pages/env_var_args.adoc
+++ b/docs/modules/ROOT/pages/env_var_args.adoc
@@ -10,7 +10,7 @@
 [source]
 ----
 export PRODUCT_CONFIG=/foo/bar/properties.yaml
-cargo run -- run
+stackable-spark-operator run
 ----
 
 or via docker:
@@ -38,7 +38,7 @@ The operator will **only** watch for resources in the provided namespace `test`:
 [source]
 ----
 export WATCH_NAMESPACE=test
-cargo run -- run
+stackable-spark-operator run
 ----
 
 or via docker:

--- a/docs/modules/ROOT/pages/env_var_args.adoc
+++ b/docs/modules/ROOT/pages/env_var_args.adoc
@@ -1,0 +1,55 @@
+
+=== PRODUCT_CONFIG
+
+*Default value*: `/etc/stackable/spark-operator/config-spec/properties.yaml`
+
+*Required*: false
+
+*Multiple values:* false
+
+[source]
+----
+export PRODUCT_CONFIG=/foo/bar/properties.yaml
+cargo run -- run
+----
+
+or via docker:
+
+----
+docker run \
+    --name spark-operator \
+    --network host \
+    --env KUBECONFIG=/home/stackable/.kube/config \
+    --env PRODUCT_CONFIG=/my/product/config.yaml \
+    --mount type=bind,source="$HOME/.kube/config",target="/home/stackable/.kube/config" \
+    docker.stackable.tech/stackable/spark-operator:latest
+----
+
+=== WATCH_NAMESPACE
+
+*Default value*: All namespaces
+
+*Required*: false
+
+*Multiple values:* false
+
+The operator will **only** watch for resources in the provided namespace `test`:
+
+[source]
+----
+export WATCH_NAMESPACE=test
+cargo run -- run
+----
+
+or via docker:
+
+[source]
+----
+docker run \
+--name spark-operator \
+--network host \
+--env KUBECONFIG=/home/stackable/.kube/config \
+--env WATCH_NAMESPACE=test \
+--mount type=bind,source="$HOME/.kube/config",target="/home/stackable/.kube/config" \
+docker.stackable.tech/stackable/spark-operator:latest
+----

--- a/docs/modules/ROOT/pages/installation.adoc
+++ b/docs/modules/ROOT/pages/installation.adoc
@@ -62,6 +62,6 @@ the time of writing).
 
 [source]
 ----
-cargo run -- crd | kubectl apply -f -
-cargo run -- run
+stackable-spark-operator crd | kubectl apply -f -
+stackable-spark-operator run
 ----

--- a/rust/crd/Cargo.toml
+++ b/rust/crd/Cargo.toml
@@ -8,12 +8,11 @@ repository = "https://github.com/stackabletech/spark-operator"
 version = "0.6.0-nightly"
 
 [dependencies]
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.12.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.13.0" }
 
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.8"
 snafu = "0.7"
-strum = { version = "0.23", features = ["derive"] }
-strum_macros = "0.23"
+strum = { version = "0.24", features = ["derive"] }

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -15,8 +15,7 @@ use stackable_operator::{
 use std::collections::BTreeMap;
 use std::hash::Hash;
 use std::str::FromStr;
-use strum::IntoEnumIterator;
-use strum_macros::EnumIter;
+use strum::{Display, EnumIter, IntoEnumIterator};
 
 #[derive(Snafu, Debug)]
 pub enum Error {
@@ -326,16 +325,7 @@ fn add_common_spark_defaults(
 
 /// Enum to manage the different Spark roles.
 #[derive(
-    Clone,
-    Debug,
-    Deserialize,
-    EnumIter,
-    Eq,
-    Hash,
-    JsonSchema,
-    PartialEq,
-    Serialize,
-    strum_macros::Display,
+    Clone, Debug, Deserialize, EnumIter, Eq, Hash, JsonSchema, PartialEq, Serialize, Display,
 )]
 pub enum SparkRole {
     #[serde(rename = "master")]

--- a/rust/operator-binary/Cargo.toml
+++ b/rust/operator-binary/Cargo.toml
@@ -8,21 +8,20 @@ repository = "https://github.com/stackabletech/spark-operator"
 version = "0.6.0-nightly"
 
 [dependencies]
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.12.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.13.0" }
 stackable-spark-crd = { path = "../crd" }
 anyhow = "1.0"
-clap = "3.0"
+clap = "3.1"
 fnv = "1.0"
 futures = { version = "0.3", features = ["compat"] }
 lazy_static = "1.4"
 serde_yaml = "0.8"
 snafu = "0.7"
-strum = "0.23"
-strum_macros = "0.23"
+strum = { version = "0.24", features = ["derive"] }
 tokio = { version = "1.17", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1"
 
 [build-dependencies]
 built = { version =  "0.5", features = ["chrono", "git2"] }
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag="0.12.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag="0.13.0" }
 stackable-spark-crd = { path = "../crd" }

--- a/rust/operator-binary/src/main.rs
+++ b/rust/operator-binary/src/main.rs
@@ -31,7 +31,10 @@ async fn main() -> anyhow::Result<()> {
     let opts = Opts::parse();
     match opts.cmd {
         Command::Crd => println!("{}", serde_yaml::to_string(&SparkCluster::crd())?,),
-        Command::Run(ProductOperatorRun { product_config }) => {
+        Command::Run(ProductOperatorRun {
+            product_config,
+            watch_namespace,
+        }) => {
             stackable_operator::utils::print_startup_string(
                 built_info::PKG_DESCRIPTION,
                 built_info::PKG_VERSION,
@@ -50,28 +53,36 @@ async fn main() -> anyhow::Result<()> {
                 stackable_operator::client::create_client(Some("spark.stackable.tech".to_string()))
                     .await?;
 
-            Controller::new(client.get_all_api::<SparkCluster>(), ListParams::default())
-                .owns(client.get_all_api::<Service>(), ListParams::default())
-                .owns(client.get_all_api::<StatefulSet>(), ListParams::default())
-                .owns(client.get_all_api::<ConfigMap>(), ListParams::default())
-                .shutdown_on_signal()
-                .run(
-                    spark_controller::reconcile,
-                    spark_controller::error_policy,
-                    Context::new(spark_controller::Ctx {
-                        client: client.clone(),
-                        product_config,
-                    }),
-                )
-                .map(|res| {
-                    report_controller_reconciled(
-                        &client,
-                        "sparkclusters.spark.stackable.tech",
-                        &res,
-                    )
-                })
-                .collect::<()>()
-                .await;
+            Controller::new(
+                watch_namespace.get_api::<SparkCluster>(&client),
+                ListParams::default(),
+            )
+            .owns(
+                watch_namespace.get_api::<Service>(&client),
+                ListParams::default(),
+            )
+            .owns(
+                watch_namespace.get_api::<StatefulSet>(&client),
+                ListParams::default(),
+            )
+            .owns(
+                watch_namespace.get_api::<ConfigMap>(&client),
+                ListParams::default(),
+            )
+            .shutdown_on_signal()
+            .run(
+                spark_controller::reconcile,
+                spark_controller::error_policy,
+                Context::new(spark_controller::Ctx {
+                    client: client.clone(),
+                    product_config,
+                }),
+            )
+            .map(|res| {
+                report_controller_reconciled(&client, "sparkclusters.spark.stackable.tech", &res)
+            })
+            .collect::<()>()
+            .await;
         }
     }
 


### PR DESCRIPTION
## Description

try
```
cargo run -- run --watch-namespace test
```
or
```
export WATCH_NAMESPACE=test
cargo run -- run
```

fixes https://github.com/stackabletech/spark-operator/issues/287

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
