### PR TITLE
[Merged by Bors] - Removed enable_monitoring from CRD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to this project will be documented in this file.
 
 ### Removed
 
-- `enableMonitoring` flag. Metrics / Monitoring always enabled ([#326]).
+- BREAKING: Removed `enableMonitoring` flag. Metrics / Monitoring always enabled ([#326]).
 
 [#289]: https://github.com/stackabletech/spark-operator/pull/289
 [#291]: https://github.com/stackabletech/spark-operator/pull/291

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,16 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- `operator-rs` `0.10.0` -> `0.13.0` ([#289], [#291], [#297]).
+- `operator-rs` `0.10.0` -> `0.15.0` ([#289], [#291], [#297], [#326]).
+
+### Removed
+
+- `enableMonitoring` flag. Metrics / Monitoring always enabled ([#326]).
 
 [#289]: https://github.com/stackabletech/spark-operator/pull/289
 [#291]: https://github.com/stackabletech/spark-operator/pull/291
 [#297]: https://github.com/stackabletech/spark-operator/pull/297
+[#326]: https://github.com/stackabletech/spark-operator/pull/326
 
 ## [0.5.0] - 2022-02-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bit-set"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,6 +364,16 @@ name = "encoding_index_tests"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
+
+[[package]]
+name = "fancy-regex"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95b4efe5be9104a4a18a9916e86654319895138be727b229820c39257c30dda"
+dependencies = [
+ "bit-set",
+ "regex",
+]
 
 [[package]]
 name = "fastrand"
@@ -729,9 +754,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.69.1"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86835e9147615457c1edc2b11c723acd1d21372e9cefa80a9d2742f6d69042d0"
+checksum = "4dcc72fdf0c491160a34d4a1bfb03f96da8a5054288d61c816d514b5c2fa49ea"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -742,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.69.1"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71f8aa916ee8290fbd0af76b3a28093a8786fccb6286902095a5243484447971"
+checksum = "94b01c722d55ffedec74cbc259b4508d8a59bf19540006ec87618f76ab156579"
 dependencies = [
  "base64",
  "bytes",
@@ -770,7 +795,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-native-tls",
- "tokio-util 0.6.9",
+ "tokio-util",
  "tower",
  "tower-http",
  "tracing",
@@ -778,9 +803,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.69.1"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da41f98f213796a68fcd4510c88b5fd36de131c1ea30d152474c3f2e1bef1a72"
+checksum = "7dd9e3535777edd122cc26fe3fe6357066b33eff63d8b919862edbe7a956a679"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -796,9 +821,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.69.1"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd6fdc2e1615a3aecd7e90fe4bda3ba32379e38193251d4ddaccba26579fe22"
+checksum = "1322e25c20dd6f18ca6baecc88bb130331e99d988df9d7a9a207f15819e05bff"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -809,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.69.1"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e8bf2258850dbc0a062b561656a1d7020fa8040d552e149f0a0361f0d6794e"
+checksum = "816c8c086f8bbcf9a4db0b7a68db90b784ef6292a57de35c64cccb90d5edfbe5"
 dependencies = [
  "ahash",
  "backoff",
@@ -827,7 +852,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "tokio",
- "tokio-util 0.6.9",
+ "tokio-util",
  "tracing",
 ]
 
@@ -1051,27 +1076,25 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
- "instant",
  "lock_api",
  "parking_lot_core",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.5"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+checksum = "995f667a6c822200b0433ac218e05582f0e2efa1b922a3fd2fbaadc5f87bab37"
 dependencies = [
  "cfg-if",
- "instant",
  "libc",
  "redox_syscall",
  "smallvec",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1168,11 +1191,11 @@ dependencies = [
 
 [[package]]
 name = "product-config"
-version = "0.3.0"
-source = "git+https://github.com/stackabletech/product-config.git?tag=0.3.0#602e7b8e1c235dd93fb3289662c1200eaa1a83db"
+version = "0.3.1"
+source = "git+https://github.com/stackabletech/product-config.git?tag=0.3.1#40c93e5283beef100c9fecdb6368f1e1480db3e8"
 dependencies = [
+ "fancy-regex",
  "java-properties",
- "regex",
  "schemars",
  "semver",
  "serde",
@@ -1499,8 +1522,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.13.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.13.0#401f4053d8c32d0fcd507d94799956181f66105d"
+version = "0.15.0"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.15.0#c7c408d476c0b7ba06833c19e5c9d2aefa5875ae"
 dependencies = [
  "backoff",
  "chrono",
@@ -1520,7 +1543,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "strum 0.23.0",
+ "strum",
  "thiserror",
  "tokio",
  "tracing",
@@ -1537,7 +1560,7 @@ dependencies = [
  "serde_yaml",
  "snafu",
  "stackable-operator",
- "strum 0.24.0",
+ "strum",
 ]
 
 [[package]]
@@ -1554,7 +1577,7 @@ dependencies = [
  "snafu",
  "stackable-operator",
  "stackable-spark-crd",
- "strum 0.24.0",
+ "strum",
  "tokio",
  "tracing",
 ]
@@ -1567,33 +1590,11 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
-dependencies = [
- "strum_macros 0.23.1",
-]
-
-[[package]]
-name = "strum"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e96acfc1b70604b8b2f1ffa4c57e59176c7dbb05d556c71ecd2f5498a1dee7f8"
 dependencies = [
- "strum_macros 0.24.0",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
-dependencies = [
- "heck 0.3.3",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
+ "strum_macros",
 ]
 
 [[package]]
@@ -1753,21 +1754,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite",
- "slab",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
@@ -1776,7 +1762,9 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project-lite",
+ "slab",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1799,7 +1787,7 @@ dependencies = [
  "pin-project",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.1",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2024,6 +2012,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5acdd78cb4ba54c0045ac14f62d8f94a03d10047904ae2a40afa1e99d8f70825"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
 
 [[package]]
 name = "xml-rs"

--- a/deploy/crd/sparkcluster.crd.yaml
+++ b/deploy/crd/sparkcluster.crd.yaml
@@ -30,9 +30,6 @@ spec:
                 config:
                   default: {}
                   properties:
-                    enableMonitoring:
-                      nullable: true
-                      type: boolean
                     logDir:
                       nullable: true
                       type: string

--- a/deploy/helm/spark-operator/crds/crds.yaml
+++ b/deploy/helm/spark-operator/crds/crds.yaml
@@ -32,9 +32,6 @@ spec:
                 config:
                   default: {}
                   properties:
-                    enableMonitoring:
-                      nullable: true
-                      type: boolean
                     logDir:
                       nullable: true
                       type: string

--- a/deploy/manifests/crds.yaml
+++ b/deploy/manifests/crds.yaml
@@ -33,9 +33,6 @@ spec:
                 config:
                   default: {}
                   properties:
-                    enableMonitoring:
-                      nullable: true
-                      type: boolean
                     logDir:
                       nullable: true
                       type: string

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -14,8 +14,6 @@ Because of `enableMonitoring: true`, all pods will be annotated for metric scrap
       name: simple-spark
     spec:
       version: "3.0.1"
-      config:
-        enableMonitoring: true
       masters:
         roleGroups:
           default:

--- a/examples/simple-spark-cluster.yaml
+++ b/examples/simple-spark-cluster.yaml
@@ -4,8 +4,6 @@ metadata:
   name: simple-spark
 spec:
   version: "3.0.1"
-  config:
-    enableMonitoring: true
   masters:
     roleGroups:
       default:

--- a/rust/crd/Cargo.toml
+++ b/rust/crd/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/stackabletech/spark-operator"
 version = "0.6.0-nightly"
 
 [dependencies]
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.13.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.15.0" }
 
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/rust/operator-binary/Cargo.toml
+++ b/rust/operator-binary/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/stackabletech/spark-operator"
 version = "0.6.0-nightly"
 
 [dependencies]
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.13.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.15.0" }
 stackable-spark-crd = { path = "../crd" }
 anyhow = "1.0"
 clap = "3.1"
@@ -23,5 +23,5 @@ tracing = "0.1"
 
 [build-dependencies]
 built = { version =  "0.5", features = ["chrono", "git2"] }
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag="0.13.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag="0.15.0" }
 stackable-spark-crd = { path = "../crd" }


### PR DESCRIPTION
## Description

- BREAKING: removed enable_monitoring flag from CRD
- updated to operator-rs 0.15.0

closes https://github.com/stackabletech/spark-operator/issues/310

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
